### PR TITLE
Support for internal concurrency in workers

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -118,6 +118,9 @@ func (c *Control) Run() {
 				}
 			}
 
+			// Save internal concurrency.
+			c.internalConcurrency.Add(float64(W) / float64(B))
+
 			if Q > B {
 				// Q > 0 (considering Q <= beta as insignificant, as in high
 				// traffic it might be difficult to spot an actual 0) means the
@@ -126,9 +129,6 @@ func (c *Control) Run() {
 				c.r = R
 				c.b = c.dx / R
 				c.k = float64(Q) / R / float64(c.mq)
-
-				// Save internal concurrency.
-				c.internalConcurrency.Add(float64(W) / float64(B))
 
 			} else if W > 0 {
 				// The system is either overscaled or in equilibrium. Use the

--- a/control/control.go
+++ b/control/control.go
@@ -68,6 +68,7 @@ func (c *Control) SetEMISize(size int) {
 
 func (c *Control) Run() {
 	firstIteration := true
+	internalConcurrency := ema.NewEMA(20)
 
 	for {
 		time.Sleep(time.Duration(c.t) * c.unit)
@@ -122,15 +123,39 @@ func (c *Control) Run() {
 				c.b = c.dx / R
 				c.k = float64(Q) / R / float64(c.mq)
 
+				// Save internal concurrency.
+				internalConcurrency.Add(float64(W) / float64(B))
+
 			} else if W > 0 {
 				// The system is either overscaled or in equilibrium. Use the
 				// mean between the two rate estimations, in order to bring the
 				// lower bound of the rate estimation (obtained though
-				// controlling beta) upwards towards the equilibrium value,
-				// given by Little's Theorem.
+				// controlling beta) up towards the equilibrium value, given by
+				// Little's Theorem.
 				// Why not using Little's Theorem right away? To avoid flapping.
+				//
+				// In our use of the Little's Theorem, we want to know the
+				// number of active workers (to know if this is lesser than β,
+				// i.e. some are starving). If the workers aren't internally
+				// concurrent, this means W is the number of active workers;
+				// however for internally concurrent workers this isn't true,
+				// we might have a very high W meaning many messages are being
+				// processed by the system, while the number of busy workers is
+				// still low.
+				// In order to have a good estimation of this, we keep an
+				// internal concurrency average from samples from when the
+				// system is queued up (Q > 0), which should mean that the
+				// system is showing its internal concurrency in W / β.
+				// We now use that to estimate number of active workers -- only
+				// if we know this number is above 1, i.e. we have confirmed
+				// internal concurrency.
+				busyWorkers := float64(W)
+				if internalConcurrency.Value() > 1.0 {
+					busyWorkers /= internalConcurrency.Value()
+				}
+
 				yBInv := R / c.dx
-				xBInv := 1.0 / float64(W)
+				xBInv := 1.0 / busyWorkers
 				// Harmonic mean to discard overscaled values
 				c.b = 2.0 / (xBInv + yBInv)
 				c.r = c.dx / c.b

--- a/control/control.go
+++ b/control/control.go
@@ -118,10 +118,11 @@ func (c *Control) Run() {
 				}
 			}
 
-			if Q > 0 {
-				// Q > 0 means the system is queued up so just use a y-dot
-				// estimation of the rate since workers are operating at full
-				// speed.
+			if Q > B {
+				// Q > 0 (considering Q <= beta as insignificant, as in high
+				// traffic it might be difficult to spot an actual 0) means the
+				// system is queued up so just use a y-dot estimation of the
+				// rate since workers are operating at full speed.
 				c.r = R
 				c.b = c.dx / R
 				c.k = float64(Q) / R / float64(c.mq)


### PR DESCRIPTION
The logic for estimating R up when the system is starved assumes no internal concurrency for the workers, so it estimates the number of active workers with the number of messages currently being worked on.

This fails in an multithreading (internally concurrent) workers scenario, leading to the control process never adjusting R up (or taking much longer than needed).

Fix this by keeping a measure of the internal concurrency by sampling the ratio of (X - Y - Q) / β, which will be larger than the unit when workers are internally concurrent.